### PR TITLE
Fix service worker initialization bug

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,5 @@
-// JavaScript Documentconst CACHE_NAME = 'lever-action-cache-v1';
+// JavaScript Document
+const CACHE_NAME = 'lever-action-cache-v1';
 const urlsToCache = [
   '/index.html',
   '/manifest.json',


### PR DESCRIPTION
## Summary
- Ensure service worker defines `CACHE_NAME` constant instead of commenting it out
- Add newline at end of service worker file

## Testing
- `node --check service-worker.js`


------
https://chatgpt.com/codex/tasks/task_e_68968e71123c832abd84cf9328caa688