### PR TITLE
Improve ebook loading and add library page

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,6 +254,7 @@ html.dark body.dark #bookmarkManager .content {
 <body>
   <!-- Toolbar with icons and bookmark buttons -->
   <div class="toolbar" id="toolbar">
+    <button id="goLibrary" aria-label="Library"><i class="fas fa-home"></i></button>
     <button id="prev" aria-label="Previous Page"><i class="fas fa-chevron-left"></i></button>
     <button id="next" aria-label="Next Page"><i class="fas fa-chevron-right"></i></button>
     <button id="toggleTheme" aria-label="Toggle Theme"><i class="fas fa-adjust"></i></button>
@@ -496,8 +497,14 @@ html.dark body.dark #bookmarkManager .content {
   // ---------------------------- 
   // INITIALIZE BOOK & GLOBAL EVENTS 
   // ---------------------------- 
-  loadBook("LeverAction.epub", "LeverAction.epub");
-  
+  const params = new URLSearchParams(window.location.search);
+  const initialBook = params.get("book") || "LeverAction.epub";
+  loadBook(initialBook, initialBook);
+
+  document.getElementById("goLibrary").addEventListener("click", function() {
+    window.location.href = "library.html";
+  });
+
   document.getElementById("prev").addEventListener("click", function() {
     if (currentRendition) currentRendition.prev();
   });

--- a/library.css
+++ b/library.css
@@ -1,0 +1,42 @@
+body {
+  margin: 0;
+  padding: 20px;
+  font-family: 'Roboto', sans-serif;
+  background-color: #f5f7fa;
+  color: #333;
+}
+header {
+  text-align: center;
+  margin-bottom: 30px;
+}
+.library {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 20px;
+}
+.book-card {
+  text-decoration: none;
+  color: inherit;
+  background: #fff;
+  border-radius: 8px;
+  padding: 15px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.book-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+}
+.book-card img {
+  width: 100%;
+  max-width: 120px;
+  height: auto;
+}
+.book-card p {
+  margin-top: 10px;
+  font-weight: 500;
+  text-align: center;
+}

--- a/library.html
+++ b/library.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EPUB Library</title>
+  <link href="https://fonts.googleapis.com/css?family=Roboto:400,500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" />
+  <link rel="stylesheet" href="library.css">
+</head>
+<body>
+  <header>
+    <h1>Library</h1>
+  </header>
+  <main class="library">
+    <a class="book-card" href="index.html?book=LeverAction.epub">
+      <img src="icons/icon-192.png" alt="Lever Action">
+      <p>Lever Action</p>
+    </a>
+  </main>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', function() {
+        navigator.serviceWorker.register('/service-worker.js');
+      });
+    }
+  </script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
       "sizes": "512x512"
     }
   ],
-  "start_url": "/index.html",
+  "start_url": "/library.html",
   "display": "standalone",
   "background_color": "#f5f7fa",
   "theme_color": "#4e54c8"

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,16 +1,13 @@
 // JavaScript Document
-const CACHE_NAME = 'lever-action-cache-v1';
+const CACHE_NAME = 'lever-action-cache-v2';
 const urlsToCache = [
   '/index.html',
+  '/library.html',
+  '/library.css',
   '/manifest.json',
   '/icons/icon-192.png',
   '/icons/icon-512.png',
-  // Include your CSS, JS, and any other assets you want to cache
-  // For example:
-  // '/styles.css',
-  // '/script.js',
-  // Also consider caching your EPUB file if desired:
-  // '/LeverAction.epub'
+  // Add additional assets like scripts or EPUB files here if needed
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- Add library navigation and load books from URL parameters for flexibility
- Create responsive library page with card-based layout
- Cache new assets and update manifest start URL

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689690560d9c832a924604bfba60dcf3